### PR TITLE
Feature: Set timezone for datetime values

### DIFF
--- a/Frends.Community.Apache.Tests/UnitTests.cs
+++ b/Frends.Community.Apache.Tests/UnitTests.cs
@@ -489,6 +489,51 @@ namespace Frends.Community.Apache.Tests
             }
         }
 
+        /// <summary>
+        /// Test case for selecting timezone for datetime.
+        /// </summary>
+        [Test]
+        public void WriteParquetFileDatetime()
+        {
+            TestTools.RemoveOutputFile(_outputFileName);
+
+            var options = new WriteCSVOptions()
+            {
+                CsvDelimiter = ";",
+                FileEncoding = FileEncoding.UTF8,
+                EnableBom = false,
+                EncodingInString = ""
+            };
+
+            var poptions = new WriteParquetOptions()
+            {
+                ParquetRowGroupSize = 5000,
+                ParquetCompressionMethod = CompressionType.Gzip,
+                Timezone = Timezone.FLEStandardTime
+            };
+
+            var input = new WriteInput()
+            {
+                CsvFileName = _inputCsvFileName,
+                OuputFileName = _outputFileName,
+                ThrowExceptionOnErrorResponse = true,
+                Schema = _commonSchema
+            };
+
+            ApacheTasks.ConvertCsvToParquet(input, options, poptions, new CancellationToken());
+
+            var hash = TestTools.MD5Hash(_outputFileName);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                var errMessage = $"File checksum doesn't match. Generated checksum: '{hash}' differs the expected checksum: '045c6a617a1d37e0a1b464ccdeea2979'";
+                Assert.IsTrue(hash == "045c6a617a1d37e0a1b464ccdeea2979", errMessage);
+            }
+            else
+            {
+                var errMessage = $"File checksum doesn't match. Generated checksum: '{hash}' differs the expected checksum: '3d6f72d1664b6a4040d2f12457264060'";
+                Assert.IsTrue(hash == "3d6f72d1664b6a4040d2f12457264060", errMessage);
+            }
+        }
 
         /// <summary>
         /// Simple csv -> parquet test case with large group size.

--- a/Frends.Community.Apache.Tests/UnitTests.cs
+++ b/Frends.Community.Apache.Tests/UnitTests.cs
@@ -125,12 +125,12 @@ namespace Frends.Community.Apache.Tests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 var errMessage = $"File checksum doesn't match. Generated checksum: '{hash}' differs the expected checksum: '045c6a617a1d37e0a1b464ccdeea2979'";
-                Assert.IsTrue(hash == "045c6a617a1d37e0a1b464ccdeea2979", errMessage);
+                Assert.AreEqual(hash, "045c6a617a1d37e0a1b464ccdeea2979", errMessage);
             }
             else
             {
                 var errMessage = $"File checksum doesn't match. Generated checksum: '{hash}' differs the expected checksum: '3d6f72d1664b6a4040d2f12457264060'";
-                Assert.IsTrue(hash == "3d6f72d1664b6a4040d2f12457264060", errMessage);
+                Assert.AreEqual(hash, "3d6f72d1664b6a4040d2f12457264060", errMessage);
             }
         }
 
@@ -217,12 +217,12 @@ namespace Frends.Community.Apache.Tests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 var errMessage = $"File checksum doesn't match. Generated checksum: '{hash}' differs the expected checksum: '6c80e7c86c8adf39b8544f7bc90724c8'";
-                Assert.IsTrue(hash == "6c80e7c86c8adf39b8544f7bc90724c8", errMessage);
+                Assert.AreEqual(hash, "6c80e7c86c8adf39b8544f7bc90724c8", errMessage);
             }
             else
             {
                 var errMessage = $"File checksum doesn't match. Generated checksum: '{hash}' differs the expected checksum: 'd5dcfc43ecd64da5f5013dab3095b777'";
-                Assert.IsTrue(hash == "d5dcfc43ecd64da5f5013dab3095b777", errMessage);
+                Assert.AreEqual(hash, "d5dcfc43ecd64da5f5013dab3095b777", errMessage);
             }
         }
 
@@ -263,12 +263,12 @@ namespace Frends.Community.Apache.Tests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 var errMessage = $"File checksum doesn't match. Generated checksum: '{hash}' differs the expected checksum: '86692194196efecc823d48384bd2a5a5'";
-                Assert.IsTrue(hash == "86692194196efecc823d48384bd2a5a5", errMessage);
+                Assert.AreEqual(hash, "86692194196efecc823d48384bd2a5a5", errMessage);
             }
             else
             {
                 var errMessage = $"File checksum doesn't match. Generated checksum: '{hash}' differs the expected checksum: '94e1bfe7bf71d94d5bd52f2de2af658b'";
-                Assert.IsTrue(hash == "94e1bfe7bf71d94d5bd52f2de2af658b", errMessage);
+                Assert.AreEqual(hash, "94e1bfe7bf71d94d5bd52f2de2af658b", errMessage);
             }
         }
 
@@ -480,12 +480,12 @@ namespace Frends.Community.Apache.Tests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 var errMessage = $"File checksum doesn't match. Generated checksum: '{hash}' differs the expected checksum: '045c6a617a1d37e0a1b464ccdeea2979'";
-                Assert.IsTrue(hash == "045c6a617a1d37e0a1b464ccdeea2979", errMessage);
+                Assert.AreEqual(hash, "045c6a617a1d37e0a1b464ccdeea2979", errMessage);
             }
             else
             {
                 var errMessage = $"File checksum doesn't match. Generated checksum: '{hash}' differs the expected checksum: '3d6f72d1664b6a4040d2f12457264060'";
-                Assert.IsTrue(hash == "3d6f72d1664b6a4040d2f12457264060", errMessage);
+                Assert.AreEqual(hash, "3d6f72d1664b6a4040d2f12457264060", errMessage);
             }
         }
 
@@ -526,12 +526,12 @@ namespace Frends.Community.Apache.Tests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 var errMessage = $"File checksum doesn't match. Generated checksum: '{hash}' differs the expected checksum: '045c6a617a1d37e0a1b464ccdeea2979'";
-                Assert.IsTrue(hash == "045c6a617a1d37e0a1b464ccdeea2979", errMessage);
+                Assert.AreEqual(hash, "045c6a617a1d37e0a1b464ccdeea2979", errMessage);
             }
             else
             {
                 var errMessage = $"File checksum doesn't match. Generated checksum: '{hash}' differs the expected checksum: '3d6f72d1664b6a4040d2f12457264060'";
-                Assert.IsTrue(hash == "3d6f72d1664b6a4040d2f12457264060", errMessage);
+                Assert.AreEqual(hash, "3d6f72d1664b6a4040d2f12457264060", errMessage);
             }
         }
 
@@ -573,12 +573,12 @@ namespace Frends.Community.Apache.Tests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 var errMessage = $"File checksum didn't match. Generated checksum: '{hash}' differs the expected checksum: '936a383c5b5f5665114f48c804f52bd3'";
-                Assert.IsTrue(hash == "936a383c5b5f5665114f48c804f52bd3", errMessage);
+                Assert.AreEqual(hash, "936a383c5b5f5665114f48c804f52bd3", errMessage);
             }
             else
             {
                 var errMessage = $"File checksum didn't match. Generated checksum: '{hash}' differs the expected checksum: 'd214884cf6a6596cbc69a174bdd60805'";
-                Assert.IsTrue(hash == "d214884cf6a6596cbc69a174bdd60805", errMessage);
+                Assert.AreEqual(hash, "d214884cf6a6596cbc69a174bdd60805", errMessage);
             }
         }
 

--- a/Frends.Community.Apache/ApacheTasks.cs
+++ b/Frends.Community.Apache/ApacheTasks.cs
@@ -152,7 +152,37 @@ namespace Frends.Community.Apache
                                                 ((bool?[])csvColumns[i])[dataIndex] = Writer.GetBooleanValueNullable(csv.GetField(i));
                                                 break;
                                             case DataType.DateTimeOffset:
-                                                ((DateTimeOffset?[])csvColumns[i])[dataIndex] = Writer.GetDateTimeOffsetValueNullable(csv.GetField(i), config.GetConfigValue(dataFields[i].Name));
+                                                var date = Writer.GetDateTimeOffsetValueNullable(csv.GetField(i), config.GetConfigValue(dataFields[i].Name));
+                                                if (date == null) ((DateTimeOffset?[])csvColumns[i])[dataIndex] = date;
+                                                else
+                                                {
+                                                    string timezone = "";
+
+                                                    switch (parquetOptions.Timezone)
+                                                    {
+                                                        case Timezone.FLEStandardTime:
+                                                            timezone = "FLE Standard Time";
+                                                            break;
+                                                        case Timezone.CentralEuropeStandardTime:
+                                                            timezone = "Central Europe Standard Time";
+                                                            break;
+                                                        case Timezone.Other:
+                                                            if (string.IsNullOrEmpty(parquetOptions.OtherTimezone))
+                                                            {
+                                                                timezone = "GMT Standard Time";
+                                                            }
+                                                            else
+                                                            {
+                                                                timezone = parquetOptions.OtherTimezone;
+                                                            }
+                                                            break;
+                                                        default:
+                                                            timezone = "GMT Standard Time";
+                                                            break;
+                                                    }
+                                                    TimeZoneInfo cetInfo = TimeZoneInfo.FindSystemTimeZoneById(timezone);
+                                                    ((DateTimeOffset?[])csvColumns[i])[dataIndex] = TimeZoneInfo.ConvertTime((DateTimeOffset)date, cetInfo);
+                                                }
                                                 break;
                                             case DataType.Decimal:
                                                 ((decimal?[])csvColumns[i])[dataIndex] = Writer.GetDecimalValueNullable(csv.GetField(i), config.GetConfigValue(dataFields[i].Name));
@@ -213,7 +243,7 @@ namespace Frends.Community.Apache
                                                 }
                                                 TimeZoneInfo cetInfo = TimeZoneInfo.FindSystemTimeZoneById(timezone);
 
-                                                var date = Writer.GetDateTimeOffsetValueNullable(csv.GetField(i), config.GetConfigValue(dataFields[i].Name));
+                                                var date = Writer.GetDateTimeOffsetValue(csv.GetField(i), config.GetConfigValue(dataFields[i].Name));
                                                 ((DateTimeOffset[])csvColumns[i])[dataIndex] = TimeZoneInfo.ConvertTime((DateTimeOffset)date, cetInfo);
                                                 break;
                                             case DataType.Decimal:

--- a/Frends.Community.Apache/ApacheTasks.cs
+++ b/Frends.Community.Apache/ApacheTasks.cs
@@ -187,7 +187,34 @@ namespace Frends.Community.Apache
                                                 ((bool[])csvColumns[i])[dataIndex] = Writer.GetBooleanValue(csv.GetField(i));
                                                 break;
                                             case DataType.DateTimeOffset:
-                                                ((DateTimeOffset[])csvColumns[i])[dataIndex] = Writer.GetDateTimeOffsetValue(csv.GetField(i), config.GetConfigValue(dataFields[i].Name));
+                                                string timezone = "";
+
+                                                switch (parquetOptions.Timezone)
+                                                {
+                                                    case Timezone.FLEStandardTime:
+                                                        timezone = "FLE Standard Time";
+                                                        break;
+                                                    case Timezone.CentralEuropeStandardTime:
+                                                        timezone = "Central Europe Standard Time";
+                                                        break;
+                                                    case Timezone.Other:
+                                                        if (string.IsNullOrEmpty(parquetOptions.OtherTimezone))
+                                                        {
+                                                            timezone = "GMT Standard Time";
+                                                        }
+                                                        else
+                                                        {
+                                                            timezone = parquetOptions.OtherTimezone;
+                                                        }
+                                                        break;
+                                                    default:
+                                                        timezone = "GMT Standard Time";
+                                                        break;
+                                                }
+                                                TimeZoneInfo cetInfo = TimeZoneInfo.FindSystemTimeZoneById(timezone);
+
+                                                var date = Writer.GetDateTimeOffsetValueNullable(csv.GetField(i), config.GetConfigValue(dataFields[i].Name));
+                                                ((DateTimeOffset[])csvColumns[i])[dataIndex] = TimeZoneInfo.ConvertTime((DateTimeOffset)date, cetInfo);
                                                 break;
                                             case DataType.Decimal:
                                                 ((decimal[])csvColumns[i])[dataIndex] = decimal.Parse(csv.GetField(i), Writer.GetCultureInfo(config.GetConfigValue(dataFields[i].Name)));

--- a/Frends.Community.Apache/Definitions.cs
+++ b/Frends.Community.Apache/Definitions.cs
@@ -46,6 +46,8 @@ namespace Frends.Community.Apache
 
     public enum CompressionType { Gzip, Snappy, None }
 
+    public enum Timezone { GMTStandardTime, CentralEuropeStandardTime, FLEStandardTime, Other }
+
     public class WriteParquetOptions
     {
         /// <summary>
@@ -66,6 +68,18 @@ namespace Frends.Community.Apache
         /// </summary>
         [DefaultValue(false)]
         public bool CountRowsBeforeProcessing { get; set; } = false;
+
+        /// <summary>
+        /// Timezone for datetime values.
+        /// </summary>
+        [DefaultValue(Timezone.GMTStandardTime)]
+        public Timezone Timezone { get; set; } = Timezone.GMTStandardTime;
+
+        /// <summary>
+        /// Timezone for other timezone value. Full list on: https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/default-time-zones?view=windows-11
+        /// </summary>
+        [UIHint(nameof(Timezone), "", Timezone.Other)]
+        public string OtherTimezone { get; set; }
     }
 
     public class WriteCSVOptions

--- a/Frends.Community.Apache/Frends.Community.Apache.csproj
+++ b/Frends.Community.Apache/Frends.Community.Apache.csproj
@@ -9,7 +9,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.0.3</Version>
+    <Version>1.1.0</Version>
 	<LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Note: Decimals, floats and doubles have "fi-FI" default culture. Decimal separat
 | Parquet row group size | number | Parquet files row group size. Batch size should be large enough because of perfomance later. | 5000 |
 | Parquet compression method | Enum | Parquet's compression level. GZip (smallest filesize) / Snappy / None | Gzip |
 | Count rows before processing | bool | Count CSV file rows before processing. If row count if smaller than Parquet row group size, decrease group size. Because this operation reads CSV file before processing, CSV file is processed two times. | false |
+| Timezone | Enum | Set timezone for datetime value. GTMStandardTime / CentralEuropeStandardTime / FLEStandardTime / Other | GTMStandardTime |
+| Other Timezone | string | Set timezone other value. | Greenwich Standard Time |
 
 ### Returns
 

--- a/README.md
+++ b/README.md
@@ -105,3 +105,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 1.0.1 | Multitarget conversion and CI |
 | 1.0.2 | Fixed issue #2: Typos/errors are difficult to find in configuration |
 | 1.0.3 | Dependency update: CsvHelper 27.1.1 to 30.0.1, Parquet.Net 3.9.0 to 3.10.0 |
+| 1.1.0 | Option for setting timezone for datetime values |


### PR DESCRIPTION
Feature requested by a client. Option window has new enum input "Timezone", with three default values and "Other" option. "Other" option gives new input for timezone name which not mentioned in enum values.
The timezone handling impelemted to "datetime"-value management.